### PR TITLE
fixed educationallearningresourcetype search

### DIFF
--- a/Backend/src/org/edu_sharing/metadataset/v2/xml/mds.xml
+++ b/Backend/src/org/edu_sharing/metadataset/v2/xml/mds.xml
@@ -676,7 +676,11 @@
 				</property>
 				<property name="ccm:classification_purpose" />
 				<property name="ccm:commonlicense_key" />
-				<property name="ccm:educationallearningresourcetype" />
+				<property name="ccm:educationallearningresourcetype">
+                                        <statement>@ccm\:educationallearningresourcetype:"${value}"</statement>
+                                        <multiple>true</multiple>
+                                        <multiplejoin>OR</multiplejoin>
+                                </property>
 				<property name="license">
 					<statement>@ccm\:commonlicense_key:"${value}"</statement>
 					<statement value="OPEN">@ccm\:commonlicense_key:"CC_0" OR @ccm\:commonlicense_key:"PDM"</statement>


### PR DESCRIPTION
Hallo zusammen,

wenn man in der Suche mehrere Materialarten auf einmal auswählt, so gibt es folgende Fehlermeldung:
`org.edu_sharing.restservices.DAOException: java.lang.RuntimeException: Trying to search for multiple values of a non-multivalue field ccm:educationallearningresourcetyp`

Ich habe hier die Suche im Standard _mds.xml_ so angepasst, dass der Fehler nicht mehr auftritt und man nach mehreren Materialarrten suchen kann.

Viele Grüße, Mirjan