### PR TITLE
Fixed NPE in sitemap-servlet

### DIFF
--- a/Backend/src/org/edu_sharing/repository/server/sitemap/SitemapServlet.java
+++ b/Backend/src/org/edu_sharing/repository/server/sitemap/SitemapServlet.java
@@ -105,7 +105,7 @@ public class SitemapServlet extends HttpServlet{
         NodeService nodeService = NodeServiceFactory.getLocalService();
 
         SearchToken token=new SearchToken();
-        if(type.equals("collection"))
+        if("collection".equals(type))
             token.setContentType(SearchService.ContentType.COLLECTIONS);
         else
             token.setContentType(SearchService.ContentType.FILES);


### PR DESCRIPTION
If the sitemap is called without the `type` parameter (such as https://some.host/edu-sharing/eduservlet/sitemap?from=0), then a NullPointerException occurs:
```
2021-04-14 06:00:15,523  INFO  [solr.component.AsyncBuildSuggestComponent] [Suggestor-alfresco-1] Built suggester shingleBasedSuggestions, took 325 ms
 java.lang.NullPointerException
        at org.edu_sharing.repository.server.sitemap.SitemapServlet.getNodes(SitemapServlet.java:108)
        at org.edu_sharing.repository.server.sitemap.SitemapServlet.doGet(SitemapServlet.java:57)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:626)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:733)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
...
```

This is fixed with this PR.
