### PR TITLE
OERSI als externes Repo anbinden

### DIFF
--- a/Backend/src/org/edu_sharing/metadataset/v2/xml/mds_oersi.xml
+++ b/Backend/src/org/edu_sharing/metadataset/v2/xml/mds_oersi.xml
@@ -1,0 +1,233 @@
+<metadataset id="oersi" label="OERSI" hidden="false">
+	<name>OERSI</name>
+	<inherit>mds</inherit>
+	<i18n>mds</i18n>
+	<!-- Begin Widgets -->
+	<widgets>
+		<!-- some overrides -->
+		<widget>
+			<id>cm:name</id>
+			<inherit>false</inherit>
+			<caption>cm_name</caption>
+			<placeholder>cm_name_placeholder</placeholder>
+			<bottomCaption>cm_name_bottom</bottomCaption>
+			<type>text</type>
+			<required>true</required>
+			<condition type="PROPERTY" negate="true">ccm:wwwurl</condition>
+			<!-- <condition>!ccm:wwwurl</condition>  -->
+		</widget>
+		<widget>
+			<id>cclom:title</id>
+			<caption>cm_title</caption>
+			<placeholder>cm_title_placeholder</placeholder>
+			<bottomCaption>cm_title_bottom</bottomCaption>
+			<type>text</type>
+			<required>true</required>
+			<hideIfEmpty>false</hideIfEmpty>
+			<condition type="PROPERTY" negate="true">ccm:wwwurl</condition>
+		</widget>
+		<!-- ein Feld in "neues Material" -->
+		<widget>
+			<id>cclom:general_description</id>
+			<type>text</type>
+			<caption>Beschreibung</caption>
+			<placeholder>Kurze Beschreibung oder Abstract ...</placeholder>			<!-- in Neues Material -> Beschreibung -->
+			<extended>false</extended>
+		</widget>
+		<widget>
+			<id>cclom:general_keyword</id>
+			<type>multivalueSuggestBadges</type>
+			<caption>lom_prop_general_keyword</caption>
+			<placeholder>lom_prop_general_keyword_placeholder</placeholder>
+			<hideIfEmpty>true</hideIfEmpty>
+			<searchable>true</searchable>
+		</widget>
+		<widget>
+			<id>cclom:general_keyword</id>
+			<template>search_suggestions</template>
+			<type>multivalueSuggestBadges</type>
+			<caption>lom_prop_general_keyword_tagcloud</caption>
+		</widget>
+		<widget>
+			<id>cclom:general_keyword</id>
+			<type>multivalueSuggestBadges</type>
+			<caption>lom_prop_general_keyword</caption>
+			<template>search</template>
+		</widget>
+		<widget>
+			<id>ccm:lifecyclecontributer_author</id>
+			<caption>Autor</caption>
+			<type>vcard</type>
+			<extended>false</extended>
+		</widget>
+		<widget>
+			<id>ccm:educationallearningresourcetype</id>
+			<caption>Materialart</caption>
+			<bottomCaption>Mehrfachnennungen sind möglich.</bottomCaption>
+			<placeholder>z.B. Arbeitsblatt, Bild, Übung, ...</placeholder>
+			<type>multivalueFixedBadges</type>
+			<valuespace>https://skohub.io/dini-ag-kim/hcrt/heads/master/w3id.org/kim/hcrt/scheme.json</valuespace>
+		</widget>
+		<widget>
+			<id>ccm:taxonid</id>
+			<caption>Fach- und Sachgebiet</caption>
+			<bottomCaption>Mehrfachnennungen sind möglich.</bottomCaption>
+			<placeholder>z.B. Ingenieurwissenschaften</placeholder>
+			<type>multivalueTree</type>
+			<valuespace>https://skohub.io/dini-ag-kim/hochschulfaechersystematik/heads/master/w3id.org/kim/hochschulfaechersystematik/scheme.json</valuespace>
+		</widget>
+		<widget>
+			<id>cclom:general_language</id>
+			<caption>Sprache(n)</caption>
+			<valuespace>valuespaces.xml</valuespace>
+			<valuespace_i18n>valuespaces_i18n</valuespace_i18n>
+			<bottomCaption>Mehrfachnennungen sind möglich.</bottomCaption>
+			<placeholder>z.B. German, English, French, ...</placeholder>
+			<type>multivalueFixedBadges</type>
+			<valuespace_sort>caption</valuespace_sort>
+		</widget>
+		<widget>
+			<id>cclom:copyright_and_other_restrictions</id>
+			<caption>Copyright und andere Einschränkungen</caption>
+			<type>checkbox</type>
+		</widget>
+		<widget>
+			<id>cclom:rights_description</id>
+			<caption>Beschreibung der Rechte</caption>
+			<type>textarea</type>
+		</widget>
+		<widget>
+			<id>cclom:location</id>
+			<caption>OERSI Ressource</caption>
+			<type>text</type>
+			<link>_BLANK</link>
+		</widget>
+		<widget>
+			<id>ccm:sourceOrganization</id>
+			<caption>Herkunft</caption>
+			<allowempty>true</allowempty>
+			<type>multivalueBadges</type>
+			<valuespace_sort>caption</valuespace_sort>
+		</widget>
+		<widget>
+			<id>ccm:published_date</id>
+			<caption>veröffentlicht</caption>
+			<type>date</type>
+			<format>MM-yyyy</format>
+		</widget>
+	</widgets>
+	<!-- End Widget  -->
+	<!-- Begin Templates -->
+	<templates>
+		<template>
+			<id>node_general_render</id>
+			<caption>dialog_upload_tab_basic</caption>			<!-- Detailansicht links -->
+			<html>
+				<![CDATA[
+					<cclom:title>
+					<cclom:general_description>
+					<cclom:general_keyword>
+					<cclom:general_language>
+					<ccm:educationallearningresourcetype>
+					<ccm:taxonid>
+					<ccm:sourceOrganization>
+					<ccm:published_date>
+					<cm:modified>
+					<cm:created>
+					<cclom:location>
+			]]>
+			</html>
+		</template>
+		<template>
+			<id>search</id>			<!-- in "Erweiterte Suche"-->
+			<html>
+				<![CDATA[
+				<ccm:taxonid>
+				<ccm:educationallearningresourcetype>
+				<ccm:lifecyclecontributer_author type="text">
+				<license>
+				]]>
+			</html>
+		</template>
+		<template>
+			<id>search_suggestions</id>
+			<rel>suggestions</rel>
+			<html>
+				<![CDATA[
+				<cclom:general_keyword>
+				]]>
+			</html>
+		</template>
+	</templates>
+	<!-- End Templates -->
+	<!-- Begin Groups -->
+	<groups>
+		<group>
+			<id>io_render</id>
+			<views>
+				<view>node_general_render</view>
+				<view>node_contributor_render</view>
+			</views>
+		</group>
+		<group>
+			<id>ngsearch</id>
+			<rendering>angular</rendering>
+			<views>
+				<view>search</view>
+			</views>
+		</group>
+	</groups>
+	<!-- End Groups -->
+	<!-- Begin Sorts -->
+	<sorts>
+		<sort>
+			<id>search</id>
+			<default>
+				<sortBy>score</sortBy>
+				<sortAscending>false</sortAscending>
+			</default>
+			<columns>
+				<column mode="descending">score</column>
+				<column>cm:modified</column>
+			</columns>
+		</sort>
+	</sorts>
+	<!-- End Sorts -->
+	<queries syntax="dsl">
+		<allowSearchWithoutCriteria>true</allowSearchWithoutCriteria>
+		<query join="AND" id="ngsearch">
+			<basequery>{"term":{"type":"LearningResource"}}</basequery>
+			<property name="ngsearchword">
+				<statement>{"multi_match":
+					{"query":"${value}","fields":["name^1","creator.name^3","description","keywords"],"type":"cross_fields","operator":"AND"}
+					}</statement>
+				<multiple>true</multiple>
+				<multiplejoin>AND</multiplejoin>
+			</property>
+			<property name="ccm:taxonid">
+				<statement>{"match":{"about.id":{"query":"${value}"}}}</statement>
+				<multiple>true</multiple>
+				<multiplejoin>OR</multiplejoin>
+			</property>
+			<property name="ccm:educationallearningresourcetype">
+				<statement>{"match":{"learningResourceType.id":{"query":"${value}"}}}</statement>
+				<multiple>true</multiple>
+				<multiplejoin>OR</multiplejoin>
+			</property>
+			<property name="ccm:lifecyclecontributer_author">
+				<statement>{"match":{"creator.name":{"query":"${value}","operator":"AND"}}}</statement>
+				<statement value="">{"term":{"type":"LearningResource"}}</statement>
+			</property>
+			<property name="license">
+				<statement>{"wildcard":{"license.id":{"value":"${value}"}}}</statement>
+				<statement value="OPEN">{"bool":{"should":[{"prefix":{"license.id":"https://creativecommons.org/publicdomain/mark"}},{"prefix":{"license.id":"https://creativecommons.org/publicdomain/zero"}},{"prefix":{"license.id":"http://creativecommons.org/publicdomain/mark"}},{"prefix":{"license.id":"http://creativecommons.org/publicdomain/zero"}}]}}</statement>
+				<statement value="OER">{"bool":{"should":[{"prefix":{"license.id":"https://creativecommons.org/publicdomain/mark"}},{"prefix":{"license.id":"https://creativecommons.org/publicdomain/zero"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by/"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by-sa/"}},{"prefix":{"license.id":"http://creativecommons.org/publicdomain/mark"}},{"prefix":{"license.id":"http://creativecommons.org/publicdomain/zero"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-sa/"}}]}}</statement>
+				<statement value="CC_BY_OPEN">{"bool":{"should":[{"prefix":{"license.id":"https://creativecommons.org/licenses/by/"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by-sa/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-sa/"}}]}}</statement>
+				<statement value="CC_BY_RESTRICTED">{"bool":{"should":[{"prefix":{"license.id":"https://creativecommons.org/licenses/by-nd/"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by-nc-sa/"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by-nc/"}},{"prefix":{"license.id":"https://creativecommons.org/licenses/by-nc-nd/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-nd/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-nc-sa/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-nc/"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by-nc-nd/"}}]}}</statement>
+				<statement value="CC_BY_ALL">{"bool":{"should":[{"prefix":{"license.id":"https://creativecommons.org/licenses/by"}},{"prefix":{"license.id":"http://creativecommons.org/licenses/by"}}]}}</statement>
+				<multiple>true</multiple>
+				<multiplejoin>OR</multiplejoin>
+			</property>
+		</query>
+	</queries>
+</metadataset>

--- a/Backend/src/org/edu_sharing/service/nodeservice/NodeServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/nodeservice/NodeServiceOersiImpl.java
@@ -1,0 +1,30 @@
+package org.edu_sharing.service.nodeservice;
+
+import org.apache.log4j.Logger;
+import org.edu_sharing.repository.client.tools.CCConstants;
+import org.edu_sharing.service.search.SearchServiceOersiImpl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NodeServiceOersiImpl extends NodeServiceAdapter {
+
+  private static final Logger logger = Logger.getLogger(SearchServiceOersiImpl.class);
+
+  public NodeServiceOersiImpl(String appId) {
+    super(appId);
+  }
+
+  @Override
+  public HashMap<String, Object> getProperties(String storeProtocol, String storeId, String nodeId) throws Throwable {
+    Map<String, Object> properties = new SearchServiceOersiImpl(appId).retrieveNode(nodeId);
+    properties.put(CCConstants.REPOSITORY_ID, this.appId);
+    return new HashMap<String, Object>(properties);
+  }
+
+  @Override
+  public String getType(String nodeId) {
+    return CCConstants.CCM_TYPE_IO;
+  }
+
+}

--- a/Backend/src/org/edu_sharing/service/provider/OersiProvider.java
+++ b/Backend/src/org/edu_sharing/service/provider/OersiProvider.java
@@ -1,0 +1,30 @@
+package org.edu_sharing.service.provider;
+
+import org.edu_sharing.service.nodeservice.NodeService;
+import org.edu_sharing.service.nodeservice.NodeServiceOersiImpl;
+import org.edu_sharing.service.permission.PermissionService;
+import org.edu_sharing.service.permission.PermissionServiceCCPublish;
+import org.edu_sharing.service.search.SearchService;
+import org.edu_sharing.service.search.SearchServiceOersiImpl;
+
+public class OersiProvider extends Provider {
+
+  public OersiProvider(String appId) {
+    super(appId);
+  }
+
+  @Override
+  public NodeService getNodeService() {
+    return new NodeServiceOersiImpl(appId);
+  }
+
+  @Override
+  public PermissionService getPermissionService() {
+    return new PermissionServiceCCPublish(appId);
+  }
+
+  @Override
+  public SearchService getSearchService() {
+    return new SearchServiceOersiImpl(appId);
+  }
+}

--- a/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
@@ -1,0 +1,391 @@
+package org.edu_sharing.service.search;
+
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.log4j.Logger;
+import org.edu_sharing.metadataset.v2.MetadataQuery;
+import org.edu_sharing.metadataset.v2.MetadataReaderV2;
+import org.edu_sharing.metadataset.v2.MetadataSetV2;
+import org.edu_sharing.metadataset.v2.tools.MetadataElasticSearchHelper;
+import org.edu_sharing.repository.client.tools.CCConstants;
+import org.edu_sharing.repository.client.tools.forms.VCardTool;
+import org.edu_sharing.repository.server.SearchResultNodeRef;
+import org.edu_sharing.repository.server.tools.ApplicationInfo;
+import org.edu_sharing.repository.server.tools.ApplicationInfoList;
+import org.edu_sharing.service.model.NodeRef;
+import org.edu_sharing.service.search.model.SearchToken;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SearchServiceOersiImpl extends SearchServiceAdapter {
+
+  private static final Logger logger = Logger.getLogger(SearchServiceOersiImpl.class);
+
+  private static final String OERSI_PROPERTY_ABOUT = "about";
+  private static final String OERSI_PROPERTY_ABOUT_ID = "id";
+  private static final String OERSI_PROPERTY_CREATOR = "creator";
+  private static final String OERSI_PROPERTY_CREATOR_NAME = "name";
+  private static final String OERSI_PROPERTY_DATE_CREATED = "dateCreated";
+  private static final String OERSI_PROPERTY_DATE_PUBLISHED = "datePublished";
+  private static final String OERSI_PROPERTY_DESCRIPTION = "description";
+  private static final String OERSI_PROPERTY_ID = "id";
+  private static final String OERSI_PROPERTY_IMAGE = "image";
+  private static final String OERSI_PROPERTY_INLANGUAGE = "inLanguage";
+  private static final String OERSI_PROPERTY_KEYWORDS = "keywords";
+  private static final String OERSI_PROPERTY_LICENSE = "license";
+  private static final String OERSI_PROPERTY_LICENSE_ID = "id";
+  private static final String OERSI_PROPERTY_LRT = "learningResourceType";
+  private static final String OERSI_PROPERTY_LRT_ID = "id";
+  private static final String OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE = "mainEntityOfPage";
+  private static final String OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE_PROVIDER = "provider";
+  private static final String OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE_PROVIDER_NAME = "name";
+  private static final String OERSI_PROPERTY_NAME = "name";
+  private static final String OERSI_PROPERTY_SOURCE_ORGANIZATION = "sourceOrganization";
+  private static final String OERSI_PROPERTY_SOURCE_ORGANIZATION_NAME = "name";
+
+  private final String oersiHost;
+  private final int oersiPort;
+  private final String oersiScheme;
+  private final String oersiPathPrefix;
+  private final String oersiIndex;
+
+  String repositoryId = null;
+
+  public SearchServiceOersiImpl(String appId) {
+    ApplicationInfo appInfo = ApplicationInfoList.getRepositoryInfoById(appId);
+    this.repositoryId = appInfo.getAppId();
+    this.oersiHost = appInfo.getString(ApplicationInfo.KEY_HOST, "oersi.de");
+    this.oersiPort = Integer.parseInt(appInfo.getString(ApplicationInfo.KEY_PORT, "443"));
+    this.oersiScheme = appInfo.getString(ApplicationInfo.KEY_PROTOCOL, "https");
+    this.oersiPathPrefix = appInfo.getString("pathprefix", "/resources/api-internal/search");
+    this.oersiIndex = appInfo.getString("index", "oer_data");
+  }
+
+  public Map<String, Object> retrieveNode(String nodeId) throws Exception {
+    return queryExecutor().executeRetrieveById(nodeId);
+  }
+
+  @Override
+  public List<? extends Suggestion> getSuggestions(MetadataSetV2 mds, String queryId, String parameterId, String value, List<org.edu_sharing.restservices.shared.MdsQueryCriteria> criteria) {
+    // TODO
+    return new ArrayList<>();
+  }
+
+  @Override
+  public SearchResultNodeRef searchV2(MetadataSetV2 mds, String query, Map<String, String[]> criteria,
+                                      SearchToken searchToken) throws Throwable {
+    OersiSearchResult result = queryExecutor().executeSearch(mds, query, criteria, searchToken.getFrom(), searchToken.getMaxResult());
+
+    SearchResultNodeRef searchResultNodeRef = new SearchResultNodeRef();
+    List<NodeRef> data = new ArrayList<>();
+    for (Map<String, Object> properties : result.records) {
+      NodeRef ref = new org.edu_sharing.service.model.NodeRefImpl(repositoryId,
+        StoreRef.STORE_REF_WORKSPACE_SPACESSTORE.getProtocol(),
+        StoreRef.STORE_REF_WORKSPACE_SPACESSTORE.getIdentifier(), new HashMap<>(properties));
+      data.add(ref);
+    }
+    searchResultNodeRef.setStartIDX(searchToken.getFrom());
+    searchResultNodeRef.setData(data);
+    searchResultNodeRef.setNodeCount((int) result.total);
+    return searchResultNodeRef;
+  }
+
+  private OersiQueryExecutor queryExecutor() {
+    OersiQueryExecutor queryExecutor = new OersiElasticsearchQueryExecutor();
+    queryExecutor.endpoint(oersiHost, oersiPort, oersiScheme, oersiPathPrefix, oersiIndex);
+    return queryExecutor;
+  }
+
+  public Map<String, Object> convertOersiRecordToProperties(String oersiId, Map<String, Object> oersiProperties) {
+    HashMap<String, Object> properties = new HashMap<>();
+    properties.put(CCConstants.SYS_PROP_NODE_UID, oersiId);
+    String title = (String) oersiProperties.get(OERSI_PROPERTY_NAME);
+    properties.put(CCConstants.LOM_PROP_GENERAL_TITLE, title);
+    String name = title.replaceAll(ApplicationInfoList.getHomeRepository().getValidatorRegexCMName(), "_").trim();
+    properties.put(CCConstants.CM_NAME, name);
+    mapOersiLicense(properties, oersiProperties);
+    mapOersiString(properties, oersiProperties, OERSI_PROPERTY_ID, CCConstants.CCM_PROP_IO_WWWURL);
+    mapOersiString(properties, oersiProperties, OERSI_PROPERTY_DESCRIPTION, CCConstants.LOM_PROP_GENERAL_DESCRIPTION);
+    mapOersiObjectArray(properties, oersiProperties, OERSI_PROPERTY_CREATOR, CCConstants.CCM_PROP_IO_REPL_LIFECYCLECONTRIBUTER_AUTHOR, o -> VCardTool.nameToVCard((String) ((Map<String, Object>) o).get(OERSI_PROPERTY_CREATOR_NAME)));
+    mapOersiObjectArray(properties, oersiProperties, OERSI_PROPERTY_SOURCE_ORGANIZATION, CCConstants.getValidGlobalName("ccm:sourceOrganization"), o -> (String) ((Map<String, Object>) o).get(OERSI_PROPERTY_SOURCE_ORGANIZATION_NAME));
+    mapOersiObjectArray(properties, oersiProperties, OERSI_PROPERTY_ABOUT, CCConstants.CCM_PROP_IO_REPL_TAXON_ID, o -> (String) ((Map<String, Object>) o).get(OERSI_PROPERTY_ABOUT_ID));
+    mapOersiObjectArray(properties, oersiProperties, OERSI_PROPERTY_LRT, CCConstants.CCM_PROP_IO_REPL_EDUCATIONAL_LEARNINGRESSOURCETYPE, o -> (String) ((Map<String, Object>) o).get(OERSI_PROPERTY_LRT_ID));
+    mapOersiStringArray(properties, oersiProperties, OERSI_PROPERTY_KEYWORDS, CCConstants.LOM_PROP_GENERAL_KEYWORD);
+    mapOersiStringArray(properties, oersiProperties, OERSI_PROPERTY_INLANGUAGE, CCConstants.LOM_PROP_GENERAL_LANGUAGE);
+    mapOersiString(properties, oersiProperties, OERSI_PROPERTY_IMAGE, CCConstants.CCM_PROP_IO_THUMBNAILURL);
+    mapOersiString(properties, oersiProperties, OERSI_PROPERTY_IMAGE, CCConstants.CM_ASSOC_THUMBNAILS);
+    properties.put(CCConstants.CCM_PROP_IO_REPLICATIONSOURCE, "OERSI");
+    properties.put(CCConstants.CCM_PROP_IO_REPLICATIONSOURCEID, oersiProperties.get(OERSI_PROPERTY_ID));
+    properties.put(CCConstants.LOM_PROP_TECHNICAL_LOCATION, oersiScheme + "://" + oersiHost + "/resources/" + oersiId);
+
+    SimpleDateFormat sdfOersi = new SimpleDateFormat("yyyy-MM-dd");
+    properties.put(CCConstants.CCM_PROP_IO_REPLICATIONSOURCETIMESTAMP, new Date().getTime());
+    mapOersiDate(properties, oersiProperties, OERSI_PROPERTY_DATE_PUBLISHED, CCConstants.CCM_PROP_IO_PUBLISHED_DATE, sdfOersi);
+    mapOersiDate(properties, oersiProperties, OERSI_PROPERTY_DATE_CREATED, CCConstants.CM_PROP_C_CREATED, sdfOersi);
+
+    List<String> provider = getArrayValues(oersiProperties, OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE,
+      o -> (String) ((Map<String, Object>) ((Map<String, Object>) o).get(OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE_PROVIDER)).get(OERSI_PROPERTY_MAIN_ENTITY_OF_PAGE_PROVIDER_NAME)
+    );
+    if (provider == null) {
+      provider = new ArrayList<>();
+    }
+    provider.add(0, "OERSI");
+    properties.put(CCConstants.CCM_PROP_IO_REPL_LIFECYCLECONTRIBUTER_CONTENT_PROVIDER, String.join(CCConstants.MULTIVALUE_SEPARATOR, provider));
+    return properties;
+  }
+
+  private static void mapOersiString(Map<String, Object> eduProperties, Map<String, Object> oersiProperties, String sourceFieldName, String targetFieldName) {
+    Object value = oersiProperties.get(sourceFieldName);
+    if (value != null && value instanceof String && StringUtils.isNotEmpty((String) value)) {
+      eduProperties.put(targetFieldName, value);
+    }
+  }
+  private static void mapOersiDate(Map<String, Object> eduProperties, Map<String, Object> oersiProperties, String sourceFieldName, String targetFieldName, SimpleDateFormat sdfOersi) {
+    Object value = oersiProperties.get(sourceFieldName);
+    if (value instanceof String && StringUtils.isNotEmpty((String) value)) {
+      try {
+        Date date = sdfOersi.parse((String) value);
+        eduProperties.put(targetFieldName, date.getTime());
+      } catch (ParseException e) {
+        logger.debug("Cannot parse OERSI date", e);
+      }
+    }
+  }
+  /**
+   * map license from JSON to edu-sharing-properties
+   */
+  private static void mapOersiLicense(Map<String, Object> eduProperties, Map<String, Object> oersiProperties) {
+    if (oersiProperties.containsKey(OERSI_PROPERTY_LICENSE)) {
+      String licenseKey = null;
+      Map<String, Object> license = (Map<String, Object>) oersiProperties.get(OERSI_PROPERTY_LICENSE);
+      String licenseUrl = (String) license.get(OERSI_PROPERTY_LICENSE_ID);
+      if (licenseUrl.startsWith("https://creativecommons.org/licenses/by/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/publicdomain/zero/1.0")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_ZERO;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/licenses/by-sa/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY_SA;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/licenses/by-nc/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY_NC;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/licenses/by-nd/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY_ND;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/licenses/by-nc-nd/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY_NC_ND;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/licenses/by-nc-sa/")) {
+        licenseKey = CCConstants.COMMON_LICENSE_CC_BY_NC_SA;
+      } else if (licenseUrl.startsWith("https://creativecommons.org/publicdomain/mark/1.0")) {
+        licenseKey = CCConstants.COMMON_LICENSE_PDM;
+      }
+      if (licenseKey != null) {
+        eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_KEY, licenseKey);
+      }
+    }
+  }
+
+  private interface JsonObjectAccessor {
+    String getValue(Object object);
+  }
+  private static void mapOersiStringArray(Map<String, Object> eduProperties, Map<String, Object> oersiProperties, String sourceFieldName, String targetFieldName) {
+    mapOersiObjectArray(eduProperties, oersiProperties, sourceFieldName, targetFieldName, String.class::cast);
+  }
+  private static void mapOersiObjectArray(Map<String, Object> eduProperties, Map<String, Object> oersiProperties, String sourceFieldName, String targetFieldName, JsonObjectAccessor accessor) {
+    List<String> valueList = getArrayValues(oersiProperties, sourceFieldName, accessor);
+    if (valueList != null && !valueList.isEmpty()) {
+      eduProperties.put(targetFieldName, String.join(CCConstants.MULTIVALUE_SEPARATOR, valueList));
+    }
+  }
+  private static List<String> getArrayValues(Map<String, Object> oersiProperties, String sourceFieldName, JsonObjectAccessor accessor) {
+    List<String> valueList = null;
+    Object value = oersiProperties.get(sourceFieldName);
+    if (value instanceof Collection) {
+      valueList = new ArrayList<>();
+      for (Object entry : (Collection) value) {
+        valueList.add(accessor.getValue(entry));
+      }
+    }
+    return valueList;
+  }
+
+  private class OersiSearchResult {
+    private long total;
+    private List<Map<String, Object>> records;
+  }
+
+  private class OersiAccessException extends Exception {
+    public OersiAccessException(String message, Exception e) {
+      super(message, e);
+    }
+  }
+
+  // note: QueryStringExecuter has problems because the query is restricted by the length of the URL -> better use ElasticsearchQuery
+  private interface OersiQueryExecutor {
+    /**
+     * OERSI API endpoint
+     */
+    void endpoint(String host, int port, String scheme, String pathPrefix, String index);
+
+    OersiSearchResult executeSearch(MetadataSetV2 mds, String query, Map<String, String[]> criteria, int from, int size) throws OersiAccessException;
+
+    Map<String, Object> executeRetrieveById(String oersiId) throws OersiAccessException;
+  }
+
+  private class OersiElasticsearchQueryExecutor implements OersiQueryExecutor {
+
+    private RestHighLevelClient client = null;
+    private String index;
+
+    @Override
+    public void endpoint(String host, int port, String scheme, String pathPrefix, String index) {
+      this.client = new RestHighLevelClient(RestClient.builder(new HttpHost(host, port, scheme)).setPathPrefix(pathPrefix));
+      this.index = index;
+    }
+
+    @Override
+    public OersiSearchResult executeSearch(MetadataSetV2 mds, String query, Map<String, String[]> criteria, int from, int size) throws OersiAccessException {
+      QueryBuilder queryBuilder = getQuery(mds, query, criteria);
+      logger.debug("es query: " + queryBuilder);
+
+      SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+      searchSourceBuilder.query(queryBuilder);
+      searchSourceBuilder.from(from);
+      searchSourceBuilder.size(size);
+      searchSourceBuilder.trackTotalHits(true);
+
+      SearchRequest searchRequest = new SearchRequest(index);
+      searchRequest.source(searchSourceBuilder);
+      try {
+        SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+        SearchHits hits = searchResponse.getHits();
+        OersiSearchResult searchResult = new OersiSearchResult();
+        searchResult.total = hits.getTotalHits().value;
+        searchResult.records = new ArrayList<>();
+        for (SearchHit hit : hits) {
+          String oersiId = hit.getId();
+          Map<String, Object> oersiProperties = hit.getSourceAsMap();
+          Map<String, Object> properties = convertOersiRecordToProperties(oersiId, oersiProperties);
+          searchResult.records.add(properties);
+        }
+        return searchResult;
+      } catch (IOException e) {
+        throw new OersiAccessException("Cannot access OERSI", e);
+      }
+    }
+
+    private QueryBuilder getQuery(MetadataSetV2 mds, String query, Map<String, String[]> criteria) {
+      MetadataQuery queryData;
+      try {
+        queryData = mds.findQuery(query, MetadataReaderV2.QUERY_SYNTAX_DSL);
+      } catch (IllegalArgumentException e) {
+        logger.info("Query " + query + " is not defined within dsl language, switching to default query...");
+        return getDefaultQuery(criteria);
+      }
+      try {
+        return MetadataElasticSearchHelper.getElasticSearchQuery(mds.getQueries(MetadataReaderV2.QUERY_SYNTAX_DSL), queryData, criteria);
+      } catch (Throwable e) {
+        logger.info("Cannot get elasticsearch query, switching to default query... ", e);
+        return getDefaultQuery(criteria);
+      }
+    }
+    private QueryBuilder getDefaultQuery(Map<String, String[]> criteria) {
+      BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
+      for (Map.Entry<String, String[]> entry : criteria.entrySet()) {
+        String joinedValues = String.join(" ", entry.getValue());
+        if (joinedValues.trim().length() == 0) {
+          continue;
+        }
+        if (MetadataSetV2.DEFAULT_CLIENT_QUERY_CRITERIA.equals(entry.getKey())) {
+          queryBuilder.must(QueryBuilders.multiMatchQuery(joinedValues)
+            .field(OERSI_PROPERTY_NAME)
+            .field(OERSI_PROPERTY_DESCRIPTION)
+            .field(OERSI_PROPERTY_KEYWORDS)
+            .field(OERSI_PROPERTY_CREATOR + "." + OERSI_PROPERTY_CREATOR_NAME)
+          );
+        } else if (CCConstants.getValidLocalName(CCConstants.LOM_PROP_GENERAL_KEYWORD).equals(entry.getKey())) {
+          queryBuilder.must(getFieldQuery(OERSI_PROPERTY_KEYWORDS, entry.getValue()));
+        } else if (CCConstants.getValidLocalName(CCConstants.CCM_PROP_IO_REPL_EDUCATIONAL_LEARNINGRESSOURCETYPE).equals(entry.getKey())) {
+          queryBuilder.must(getFieldQuery(OERSI_PROPERTY_LRT + "." + OERSI_PROPERTY_LRT_ID, entry.getValue()));
+        } else if (CCConstants.getValidLocalName(CCConstants.CCM_PROP_IO_REPL_TAXON_ID).equals(entry.getKey())) {
+          queryBuilder.must(getFieldQuery(OERSI_PROPERTY_ABOUT + "." + OERSI_PROPERTY_ABOUT_ID, entry.getValue()));
+        } else if (CCConstants.getValidLocalName(CCConstants.CCM_PROP_IO_REPL_LIFECYCLECONTRIBUTER_AUTHOR).equals(entry.getKey())) {
+          queryBuilder.must(
+            QueryBuilders.matchQuery(OERSI_PROPERTY_CREATOR + "." + OERSI_PROPERTY_CREATOR_NAME, joinedValues).operator(Operator.AND)
+          );
+        } else if ("license".equals(entry.getKey())) {
+          Set<String> licensePrefixes = new HashSet<>();
+          for (String licenseValue : entry.getValue()) {
+            switch (licenseValue) {
+              case "OPEN":
+                licensePrefixes.add("https://creativecommons.org/publicdomain/mark");
+                licensePrefixes.add("https://creativecommons.org/publicdomain/zero/");
+                break;
+              case "OER":
+                licensePrefixes.add("https://creativecommons.org/publicdomain/mark");
+                licensePrefixes.add("https://creativecommons.org/publicdomain/zero/");
+                licensePrefixes.add("https://creativecommons.org/licenses/by/");
+                licensePrefixes.add("https://creativecommons.org/licenses/by-sa/");
+                break;
+              case "CC_BY_RESTRICTED":
+                licensePrefixes.add("https://creativecommons.org/licenses/by-nd/");
+                licensePrefixes.add("https://creativecommons.org/licenses/by-nc-sa/");
+                licensePrefixes.add("https://creativecommons.org/licenses/by-nc/");
+                licensePrefixes.add("https://creativecommons.org/licenses/by-nc-nd/");
+                break;
+              default:
+                break;
+            }
+          }
+          BoolQueryBuilder fieldQueryBuilder = QueryBuilders.boolQuery();
+          for (String prefix : licensePrefixes) {
+            fieldQueryBuilder.should(QueryBuilders.prefixQuery(OERSI_PROPERTY_LICENSE + "." + OERSI_PROPERTY_LICENSE_ID, prefix));
+          }
+          queryBuilder.must(fieldQueryBuilder);
+        }
+      }
+      return queryBuilder;
+    }
+    private QueryBuilder getFieldQuery(String fieldName, String[] values) {
+      BoolQueryBuilder fieldQueryBuilder = QueryBuilders.boolQuery();
+      for (String value : values) {
+        fieldQueryBuilder.should(QueryBuilders.matchQuery(fieldName, value));
+      }
+      return fieldQueryBuilder;
+    }
+
+    @Override
+    public Map<String, Object> executeRetrieveById(String oersiId) throws OersiAccessException {
+      GetRequest getRequest = new GetRequest(index, oersiId);
+      try {
+        GetResponse getResponse = client.get(getRequest, RequestOptions.DEFAULT);
+        Map<String, Object> oersiProperties = getResponse.getSourceAsMap();
+        return convertOersiRecordToProperties(oersiId, oersiProperties);
+      } catch (IOException e) {
+        throw new OersiAccessException("Cannot access OERSI", e);
+      }
+    }
+  }
+}

--- a/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
@@ -203,12 +203,12 @@ public class SearchServiceOersiImpl extends SearchServiceAdapter {
       } else if (licenseUrl.startsWith("https://creativecommons.org/publicdomain/mark/1.0")) {
         licenseKey = CCConstants.COMMON_LICENSE_PDM;
       }
-      Matcher versionMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/([0-9.]+)(\\/.+)?").matcher(licenseUrl);
+      Matcher versionMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/([0-9.]+)(\\/.*)?").matcher(licenseUrl);
       if (versionMatcher.matches()) {
         String licenseVersion = versionMatcher.group(1);
         eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_CC_VERSION, licenseVersion);
       }
-      Matcher countryMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/(?:[0-9.]+)\\/([a-z][a-z])(\\/.+)?").matcher(licenseUrl);
+      Matcher countryMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/(?:[0-9.]+)\\/([a-z][a-z])(\\/.*)?").matcher(licenseUrl);
       if (countryMatcher.matches()) {
         String countryCode = countryMatcher.group(1).toUpperCase();
         eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_CC_LOCALE, countryCode);

--- a/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
@@ -41,6 +41,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SearchServiceOersiImpl extends SearchServiceAdapter {
 
@@ -201,8 +203,19 @@ public class SearchServiceOersiImpl extends SearchServiceAdapter {
       } else if (licenseUrl.startsWith("https://creativecommons.org/publicdomain/mark/1.0")) {
         licenseKey = CCConstants.COMMON_LICENSE_PDM;
       }
+      Matcher versionMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/([0-9.]+)(\\/.+)?").matcher(licenseUrl);
+      if (versionMatcher.matches()) {
+        String licenseVersion = versionMatcher.group(1);
+        eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_CC_VERSION, licenseVersion);
+      }
+      Matcher countryMatcher = Pattern.compile("https?:\\/\\/creativecommons.org\\/(?:licenses|licences|publicdomain)\\/(?:[a-zA-Z-]+)\\/(?:[0-9.]+)\\/([a-z][a-z])(\\/.+)?").matcher(licenseUrl);
+      if (countryMatcher.matches()) {
+        String countryCode = countryMatcher.group(1).toUpperCase();
+        eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_CC_LOCALE, countryCode);
+      }
       if (licenseKey != null) {
         eduProperties.put(CCConstants.CCM_PROP_IO_COMMONLICENSE_KEY, licenseKey);
+        eduProperties.put(CCConstants.VIRT_PROP_LICENSE_URL, licenseUrl);
       }
     }
   }


### PR DESCRIPTION
Hallo zusammen,

mit diesem PR wird es ermöglicht den OER-Suchindex (https://oersi.de) als externes Repo in edu-sharing anzubinden.

Dazu werden hier Implementierungen der vorhandenen Schnittstelle hinzugefügt (`org.edu_sharing.service.nodeservice.NodeServiceAdapter`, `org.edu_sharing.service.provider.Provider`, `org.edu_sharing.service.search.SearchServiceAdapter`)

Die Anbindung in edu-sharing kann zB über folgende Konfiguration erfolgen
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
<properties>
  <comment>oersi as remote repo for search</comment>
  <entry key="host">oersi.de</entry>
  <entry key="port">443</entry>
  <entry key="protocol">https</entry>
  <entry key="pathprefix">/resources/api-internal/search</entry>
  <entry key="index">oer_data</entry>
  <entry key="searchable">true</entry>
  <entry key="auth_by_app_sendmail">false</entry>
  <entry key="appcaption">Überregionale Suche</entry>
  <entry key="appid">oersi</entry>
  <entry key="devmode">false</entry>
  <entry key="is_home_node">false</entry>
  <entry key="type">REPOSITORY</entry>
  <entry key="repositorytype">OERSI</entry>
  <entry key="metadatasetsV2">mds_oersi</entry>
  <entry key="searchclass">org.edu_sharing.repository.server.MCAlfrescoAPIClient</entry>
  <entry key="searchService">org.edu_sharing.service.search.SearchServiceOersiImpl</entry>
  <entry key="permissionService">org.edu_sharing.service.permission.PermissionServiceCCPublish</entry>
  <entry key="nodeService">org.edu_sharing.service.nodeservice.NodeServiceOersiImpl</entry>
  <entry key="remote_provider">org.edu_sharing.service.provider.OersiProvider</entry>
  <entry key="trustedclient">false</entry>
</properties>
```

Die Konfiguration der Suche selbst erfolgt über die `mds_oersi.xml` bzw `mds_oersi_override.xml`. Eine sinnvolle Default-Konfiguration ist im PR enthalten.
