### PR TITLE
fix: CCM_PROP_LICENSE_CC_LOCALE must be Array of null

### DIFF
--- a/Frontend/src/app/modules/management-dialogs/license/license.component.ts
+++ b/Frontend/src/app/modules/management-dialogs/license/license.component.ts
@@ -493,7 +493,7 @@ export class WorkspaceLicenseComponent  {
             prop[RestConstants.CCM_PROP_LICENSE_SOURCE_URL] = null;
             prop[RestConstants.CCM_PROP_LICENSE_PROFILE_URL] = null;
             prop[RestConstants.CCM_PROP_LICENSE_CC_VERSION] = null;
-            prop[RestConstants.CCM_PROP_LICENSE_CC_LOCALE] = null;
+            prop[RestConstants.CCM_PROP_LICENSE_CC_LOCALE] = [null];
             if (this.ccTitleOfWork) {
                 prop[RestConstants.CCM_PROP_LICENSE_TITLE_OF_WORK] = [this.ccTitleOfWork];
             }


### PR DESCRIPTION
Hello @torsten-simon 

In the frontend, for licenses 3.0,2.0 and 1.0 when we choose **international** it will not update the  **CCM_PROP_LICENSE_CC_LOCALE**  property, it keeps the last value, the same problem when we choose a license version 4.0 the **CCM_PROP_LICENSE_CC_LOCALE** it keeps the last value for this property, Looks like Backend will ignore property that has value null, so in this case must be an array of null. 