### PR TITLE
Add option to open OER in new tab

### DIFF
--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -1136,6 +1136,7 @@ export class OptionsHelperService implements OnDestroy {
             UIHelper.openUrl(url, this.bridge, OPEN_URL_MODE.Blank)
         });
         openInNewTabNode.constrains = [Constrain.Files, Constrain.NoBulk];
+        openInNewTabNode.scopes = [Scope.Search, Scope.CollectionsReferences, Scope.WorkspaceList];
         // openInNewTabNode.permissions = [RestConstants.ACCESS_CHANGE_PERMISSIONS];
         openInNewTabNode.group = DefaultGroups.View;
         openInNewTabNode.priority = 0;

--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -1130,7 +1130,7 @@ export class OptionsHelperService implements OnDestroy {
         metadataSidebar.isToggle = true;
 
         // add new option to open the Node in new tab
-        const openInNewTabNode = new OptionItem('OPTIONS.OPENINNEWTAB', 'open_in_new', (node) => {
+        const openInNewTabNode = new OptionItem('OPTIONS.OPEN_IN_NEW_TAB', 'open_in_new', (node) => {
             node = this.getObjects(node)[0];
             const url = this.nodeHelper.getNodeUrl(node);
             UIHelper.openUrl(url, this.bridge, OPEN_URL_MODE.Blank)

--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -1181,7 +1181,6 @@ export class OptionsHelperService implements OnDestroy {
         // open in new tab
         options.push(openInNewTabNode);
 
-
         return options;
     }
 

--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -56,6 +56,7 @@ import {
     NodeEntriesDisplayType
 } from './components/node-entries-wrapper/entries-model';
 import {MainNavService} from '../common/services/main-nav.service';
+import {OPEN_URL_MODE} from "../core-module/ui/ui-constants";
 
 
 export class OptionsHelperConfig {
@@ -1128,6 +1129,17 @@ export class OptionsHelperService implements OnDestroy {
         metadataSidebar.group = DefaultGroups.Toggles;
         metadataSidebar.isToggle = true;
 
+        // add new option to open the Node in new tab
+        const openInNewTabNode = new OptionItem('OPTIONS.OPENINNEWTAB', 'open_in_new', (node) => {
+            node = this.getObjects(node)[0];
+            const url = this.nodeHelper.getNodeUrl(node);
+            UIHelper.openUrl(url, this.bridge, OPEN_URL_MODE.Blank)
+        });
+        openInNewTabNode.constrains = [Constrain.Files, Constrain.NoBulk];
+        openInNewTabNode.permissions = [RestConstants.ACCESS_CHANGE_PERMISSIONS];
+        openInNewTabNode.group = DefaultGroups.View;
+        openInNewTabNode.priority = 0;
+
         options.push(applyNode);
         options.push(debugNode);
         options.push(acceptProposal);
@@ -1166,6 +1178,9 @@ export class OptionsHelperService implements OnDestroy {
         options.push(reportNode);
         options.push(toggleViewType);
         options.push(metadataSidebar);
+        // open in new tab
+        options.push(openInNewTabNode);
+
 
         return options;
     }

--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -1139,7 +1139,7 @@ export class OptionsHelperService implements OnDestroy {
         openInNewTabNode.scopes = [Scope.Search, Scope.CollectionsReferences, Scope.WorkspaceList];
         // openInNewTabNode.permissions = [RestConstants.ACCESS_CHANGE_PERMISSIONS];
         openInNewTabNode.group = DefaultGroups.View;
-        openInNewTabNode.priority = 0;
+        openInNewTabNode.priority = 80;
 
         options.push(applyNode);
         options.push(debugNode);

--- a/Frontend/src/app/core-ui-module/options-helper.service.ts
+++ b/Frontend/src/app/core-ui-module/options-helper.service.ts
@@ -1136,7 +1136,7 @@ export class OptionsHelperService implements OnDestroy {
             UIHelper.openUrl(url, this.bridge, OPEN_URL_MODE.Blank)
         });
         openInNewTabNode.constrains = [Constrain.Files, Constrain.NoBulk];
-        openInNewTabNode.permissions = [RestConstants.ACCESS_CHANGE_PERMISSIONS];
+        // openInNewTabNode.permissions = [RestConstants.ACCESS_CHANGE_PERMISSIONS];
         openInNewTabNode.group = DefaultGroups.View;
         openInNewTabNode.priority = 0;
 

--- a/Frontend/src/assets/i18n/common/de.json
+++ b/Frontend/src/assets/i18n/common/de.json
@@ -654,7 +654,7 @@
         "LIST_SETTINGS": "Liste konfigurieren",
         "METADATA_SIDEBAR": "Materialinformationen",
         "ACCESSIBILITY": "Barrierefreiheit",
-        "OPENINNEWTAB": "In neuem Tab öffnen"
+        "OPEN_IN_NEW_TAB": "In neuem Tab öffnen"
     },
     "NO_SIZE": "-",
     "VERSION_COMMENT": "Versionskommentar",

--- a/Frontend/src/assets/i18n/common/de.json
+++ b/Frontend/src/assets/i18n/common/de.json
@@ -653,7 +653,8 @@
         "SWITCH_TO_CARDS_VIEW": "Zur Kachelansicht wechseln",
         "LIST_SETTINGS": "Liste konfigurieren",
         "METADATA_SIDEBAR": "Materialinformationen",
-        "ACCESSIBILITY": "Barrierefreiheit"
+        "ACCESSIBILITY": "Barrierefreiheit",
+        "OPENINNEWTAB": "In neuem Tab öffnen"
     },
     "NO_SIZE": "-",
     "VERSION_COMMENT": "Versionskommentar",

--- a/Frontend/src/assets/i18n/common/en.json
+++ b/Frontend/src/assets/i18n/common/en.json
@@ -612,7 +612,8 @@
         "SWITCH_TO_CARDS_VIEW": "Switch to cards view",
         "LIST_SETTINGS": "Configure List",
         "METADATA_SIDEBAR": "Material details",
-        "ACCESSIBILITY": "Accessibility"
+        "ACCESSIBILITY": "Accessibility",
+        "OPENINNEWTAB": "Open in new tab"
     },
     "NO_SIZE": "-",
     "VERSION_COMMENT": "Version comment",

--- a/Frontend/src/assets/i18n/common/en.json
+++ b/Frontend/src/assets/i18n/common/en.json
@@ -613,7 +613,7 @@
         "LIST_SETTINGS": "Configure List",
         "METADATA_SIDEBAR": "Material details",
         "ACCESSIBILITY": "Accessibility",
-        "OPENINNEWTAB": "Open in new tab"
+        "OPEN_IN_NEW_TAB": "Open in new tab"
     },
     "NO_SIZE": "-",
     "VERSION_COMMENT": "Version comment",


### PR DESCRIPTION
Hello @torsten-simon 

In Edu-sharing, some users would like to have the widespread/known function of right-clicking to open a new tab (open an OER in a new tab). Currently in edu-sharing in order to open an OER in a new tab, is by clicking **ctrl+left-click**.

In this pull request, we add a new option, in OptionsHelper, to open an OER in a new tab.
