### PR TITLE
Add workaround for port in oersi http host header

### DIFF
--- a/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
@@ -2,7 +2,9 @@ package org.edu_sharing.service.search;
 
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHeader;
 import org.apache.log4j.Logger;
 import org.edu_sharing.metadataset.v2.MetadataQuery;
 import org.edu_sharing.metadataset.v2.MetadataReader;
@@ -21,6 +23,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.Operator;
@@ -280,7 +283,10 @@ public class SearchServiceOersiImpl extends SearchServiceAdapter {
 
     @Override
     public void endpoint(String host, int port, String scheme, String pathPrefix, String index) {
-      this.client = new RestHighLevelClient(RestClient.builder(new HttpHost(host, port, scheme)).setPathPrefix(pathPrefix));
+      RestClientBuilder builder = RestClient.builder(new HttpHost(host, port, scheme));
+      builder.setPathPrefix(pathPrefix);
+      builder.setDefaultHeaders(new Header[] {new BasicHeader("Host", host)});
+      this.client = new RestHighLevelClient(builder);
       this.index = index;
     }
     @Override

--- a/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
+++ b/Backend/src/org/edu_sharing/service/search/SearchServiceOersiImpl.java
@@ -82,7 +82,7 @@ public class SearchServiceOersiImpl extends SearchServiceAdapter {
   public SearchServiceOersiImpl(String appId) {
     ApplicationInfo appInfo = ApplicationInfoList.getRepositoryInfoById(appId);
     this.repositoryId = appInfo.getAppId();
-    this.oersiHost = appInfo.getString(ApplicationInfo.KEY_HOST, "oersi.de");
+    this.oersiHost = appInfo.getString(ApplicationInfo.KEY_HOST, "oersi.org");
     this.oersiPort = Integer.parseInt(appInfo.getString(ApplicationInfo.KEY_PORT, "443"));
     this.oersiScheme = appInfo.getString(ApplicationInfo.KEY_PROTOCOL, "https");
     this.oersiPathPrefix = appInfo.getString("pathprefix", "/resources/api-internal/search");


### PR DESCRIPTION
Die OERSI-Verbindung funktioniert nicht mit OERSI-Instanzen, die den Port der OERSI-Verbindung im "Host"-Header der http-Verbindung nicht direkt akzeptieren. So gibt es beispielsweise für `Host: oersi.org:443` eine Weiterleitung auf `oersi.org` (http-Status 301). Das Setzen des Ports im "Host-Header" ist aber Standard-Verhalten des genutzen "ElasticSearch-RestClient" (siehe auch https://github.com/elastic/elasticsearch/issues/71026)

Daher wird mit diesem PR ein Workaround eingebaut und damit der Host der OERSI-Verbindung immer direkt im http-Header gesetzt - ohne Port.