### PR TITLE
Fix manual OAI XML import

### DIFF
--- a/Backend/services/core/src/main/java/org/edu_sharing/restservices/admin/v1/AdminApi.java
+++ b/Backend/services/core/src/main/java/org/edu_sharing/restservices/admin/v1/AdminApi.java
@@ -866,6 +866,7 @@ public class AdminApi {
 
 	@POST
 	@Path("/import/oai/xml")
+	@Consumes({ "multipart/form-data" })
 	@Operation(summary = "Import single xml via oai (for testing)")
 	@ApiResponses(value = { @ApiResponse(responseCode="200", description=RestConstants.HTTP_200, content = @Content(schema = @Schema(implementation = Node.class))),
 			@ApiResponse(responseCode="400", description=RestConstants.HTTP_400, content = @Content(schema = @Schema(implementation = ErrorResponse.class))),


### PR DESCRIPTION
At least in edu-sharing 7.x and 8.x, it is not possible to import an IEEE LOM file manually through the admin interface. When tried, Tomcat returns a generic `415 Unsupported Media Type` error. This is caused by the missing `@Consumes` statement for the given route, since a default of `application/json` is assumed.

Therefore, this commit fixes the erroneous behavior by allowing the correct content-type of `multipart/form-data`. This content-type is later expected in the code, such as by the call to `@FormDataParam("xml")` (returning the XML submitted).

<hr>

I tested the behavior with a local edu-sharing instance and was able to confirm the functionality of my fix and therefore want to contribute this change. I am, however, unsure which branch to choose and therefore went with the current default `maven/fixes/7.0`, even though the behavior is also broken in edu-sharing 8.x.