### PR TITLE
Fixing invalid Content-Type in HttpQueryTool.java

### DIFF
--- a/Backend/services/core/src/main/java/org/edu_sharing/repository/server/tools/HttpQueryTool.java
+++ b/Backend/services/core/src/main/java/org/edu_sharing/repository/server/tools/HttpQueryTool.java
@@ -188,7 +188,7 @@ public class HttpQueryTool {
 
 		Header[] headersContentType = method.getHeaders("Content-Type");
 		if(headersContentType == null || headersContentType.length == 0){
-			method.setHeader("Content-Type", "charset=UTF-8");
+			method.setHeader("Content-Type", "text/plain; charset=UTF-8");
 		}
 
 


### PR DESCRIPTION
I was working on an OAI-PMH repository endpoint and wanted to test it by importing data into edu-sharing. However the import failed because the importer sends a request with an invalid Content-Type which causes an error on my side.
According to the mozilla docs there must be a MIME type/subtype pair before any parameter:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types