### PR TITLE
Configure Minimum Character Length for Autocomplete in "Freigabe" and in "Workflow"

### DIFF
--- a/Backend/alfresco/module/src/main/java/org/edu_sharing/alfresco/service/config/model/Values.java
+++ b/Backend/alfresco/module/src/main/java/org/edu_sharing/alfresco/service/config/model/Values.java
@@ -67,4 +67,5 @@ public class Values implements Serializable {
 	@XmlElement	public String customCSS;
 	@XmlElement	public ConfigThemeColors themeColors;
 	@XmlElement	public ConfigPrivacy privacy;
+	@XmlElement public Integer minSuggestionLength;
 }

--- a/Frontend/src/app/features/dialogs/dialog-modules/share-dialog/share-dialog.component.html
+++ b/Frontend/src/app/features/dialogs/dialog-modules/share-dialog/share-dialog.component.html
@@ -21,6 +21,7 @@
         <es-authority-search-input
           [globalSearchAllowed]="globalAllowed"
           (onChooseAuthority)="addSuggestion($event)"
+          [minSuggestionLength]="minSuggestionLength"
         ></es-authority-search-input>
         <div class="hintNoFuzzy" *ngIf="globalSearch && !fuzzyAllowed">
           {{ 'WORKSPACE.SHARE.NO_FUZZY' | translate }}

--- a/Frontend/src/app/features/dialogs/dialog-modules/share-dialog/share-dialog.component.ts
+++ b/Frontend/src/app/features/dialogs/dialog-modules/share-dialog/share-dialog.component.ts
@@ -156,7 +156,10 @@ export class ShareDialogComponent implements OnInit, AfterViewInit {
     private originalPermissions: LocalPermissions[];
     showChooseType = false;
     private showChooseTypeList: Permission;
-
+    /**
+     * The minimum input length required for suggestions.
+     */
+    minSuggestionLength= 2;
     constructor(
         @Inject(CARD_DIALOG_DATA) public data: ShareDialogData,
         private dialogRef: CardDialogRef<ShareDialogData, ShareDialogResult>,
@@ -202,6 +205,8 @@ export class ShareDialogComponent implements OnInit, AfterViewInit {
             this.isSafe = data.currentScope != null;
             this.updateToolpermissions();
         });
+
+        this.minSuggestionLength=this.config.instant("minSuggestionLength", 2);
         // Call in constructor to avoid changed-after-checked error when setting `isLoading` state.
         this.initNodes();
     }

--- a/Frontend/src/app/features/dialogs/dialog-modules/workflow-dialog/workflow-dialog.component.html
+++ b/Frontend/src/app/features/dialogs/dialog-modules/workflow-dialog/workflow-dialog.component.html
@@ -6,6 +6,7 @@
         [globalSearchAllowed]="globalAllowed"
         [groupType]="TYPE_EDITORIAL"
         [showRecent]="false"
+        [minSuggestionLength]="minSuggestionLength"
         (onChooseAuthority)="addSuggestion($event)"
         [placeholder]="'WORKSPACE.WORKFLOW.RECEIVERS'"
         hint="{{ 'WORKSPACE.WORKFLOW.RECEIVERS_HINT' | translate }}"

--- a/Frontend/src/app/features/dialogs/dialog-modules/workflow-dialog/workflow-dialog.component.ts
+++ b/Frontend/src/app/features/dialogs/dialog-modules/workflow-dialog/workflow-dialog.component.ts
@@ -46,6 +46,10 @@ export class WorkflowDialogComponent {
     receivers: WorkflowReceiver[] = [];
     status = WORKFLOW_STATUS_UNCHECKED;
     validStatus: WorkflowDefinition[];
+    /**
+     * The minimum input length required for suggestions.
+     */
+    minSuggestionLength= 2;
 
     private initialStatus = WORKFLOW_STATUS_UNCHECKED;
     private nodes: Node[] = this.data.nodes;
@@ -79,6 +83,7 @@ export class WorkflowDialogComponent {
             }
         });
         void this.initNodes(this.data.nodes);
+        this.minSuggestionLength=this.config.instant("minSuggestionLength", 2);
     }
 
     isAllowedAsNext(status: WorkflowDefinition) {

--- a/Frontend/src/app/shared/components/authority-search-input/authority-search-input.component.ts
+++ b/Frontend/src/app/shared/components/authority-search-input/authority-search-input.component.ts
@@ -70,6 +70,11 @@ export class AuthoritySearchInputComponent {
     @Input() label: string;
     @Input() placeholder = 'WORKSPACE.INVITE_FIELD';
     @Input() hint = '';
+    /**
+     * The minimum length of input required to trigger suggestions.
+     * Default value is 2.
+     */
+    @Input() minSuggestionLength: number = 2;
 
     @Output() onChooseAuthority = new EventEmitter<Authority | any>();
 
@@ -89,7 +94,7 @@ export class AuthoritySearchInputComponent {
             startWith(''),
             debounceTime(500),
             filter(() => {
-                if (this.input.value?.length < 2) {
+                if (this.input.value?.length < this.minSuggestionLength) {
                     this.suggestionLoading.next(false);
                     return false;
                 }
@@ -124,7 +129,7 @@ export class AuthoritySearchInputComponent {
     }
 
     getSuggestions(inputValue: string): Observable<SuggestionGroup[]> {
-        if (inputValue.length < 2) {
+        if (inputValue.length < this.minSuggestionLength)  {
             if (this.showRecent && this.restConnector.getCurrentLogin()?.currentScope == null) {
                 return this.getRecentSuggestions();
             } else {


### PR DESCRIPTION
This update introduces the ability for administrators to specify the minimum number of characters required for autocomplete suggestions in the "Freigabe" and "Workflow" panels. With this enhancement, users will only see suggestions that match the initial characters they enter.

#### We aim to include this implementation in either version 8.1 or 9.0.

## Identification of Dead Code

In the `AuthoritySearchInputComponent`, we have two sections of code:

```typescript
this.suggestionGroups$ = this.input.valueChanges.pipe(
    startWith(''),
    debounceTime(500),
    filter(() => {
        if (this.input.value?.length < 2) {
            this.suggestionLoading.next(false);
            return false;
        }
        return true;
    }),
    tap(() => this.suggestionLoading.next(true)),
    switchMap((value) => this.getSuggestions(value)),
    tap(() => this.suggestionLoading.next(false)),
);
```

and also

```js
getSuggestions(inputValue: string): Observable<SuggestionGroup[]> {
    if (inputValue.length < 2) {
        if (this.showRecent && this.restConnector.getCurrentLogin()?.currentScope == null) {
            return this.getRecentSuggestions();
        } else {
            return of(null);
        }
    } else {
        switch (this.mode) {
            case AuthoritySearchMode.Users:
                return this.getUsersSuggestions(inputValue);
            case AuthoritySearchMode.UsersAndGroups:
                return this.getUsersAndGroupsSuggestions(inputValue);
            case AuthoritySearchMode.Organizations:
                return this.getOrganizationsSuggestions(inputValue);
        }
    }
}
```


Upon review, looks like the code inside the if block in the **getSuggestions**

method will never be executed due to the condition in the first part of the code block.

> P.S: The logic, for this pull request, has been implemented in both sections.